### PR TITLE
Implement retrieval of value list hierarchy information from ECCAIRS taxonomy service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ In particular it serves to:
 - parse ECCAIRS Taxonomy distribution
 - parse RIT Taxonomy distribution
 - comparison of ECCAIRS and RIT versions
-- (experimental) export of ECCAIRS into SNOMED format 
+- (experimental) export of ECCAIRS into SNOMED format
+
+### Value Lists
+
+The taxonomy XML file provided by ECCAIRS no longer (since version 5.1.0.0) contains hierarchy information on value lists. Therefore, the tool attempts
+to resolve the hierarchy information from the ECCAIRS taxonomy service itself. For this to work, the taxonomy service URL must be configured.
 
 ## Import ECCAIRS taxonomy into an RDF repository
 1. Build the project using `gradle build`

--- a/eccairs-service/build.gradle
+++ b/eccairs-service/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.data:spring-data-commons'
+    implementation('com.jayway.jsonpath:json-path:2.8.0')
 
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'com.konghq:unirest-java:3.11.11'

--- a/eccairs-service/src/main/java/com/github/psiotwo/eccairs/JenaEccairsDao.java
+++ b/eccairs-service/src/main/java/com/github/psiotwo/eccairs/JenaEccairsDao.java
@@ -5,6 +5,8 @@ import com.github.psiotwo.eccairs.rdf.EccairsTaxonomyToRdf;
 import com.github.psiotwo.eccairs.rdf.EccairsUtils;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.github.psiotwo.eccairs.rdf.TaxonomyService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.ParameterizedSparqlString;
@@ -20,18 +22,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class JenaEccairsDao implements EccairsDao {
 
-    private Conf conf;
+    private final Conf conf;
 
-    @Autowired
-    public JenaEccairsDao(final Conf conf) {
+    private final TaxonomyService taxonomyService;
+
+    public JenaEccairsDao(final Conf conf, TaxonomyService taxonomyService) {
         this.conf = conf;
+        this.taxonomyService = taxonomyService;
     }
 
     public void saveEccairs(EccairsDictionary dictionary) {
         log.info("Saving: '{}, ver. {}'", dictionary.getTaxonomy(), dictionary.getVersion());
 
-        final EccairsTaxonomyToRdf exporter =
-            new EccairsTaxonomyToRdf(conf.getBaseUri(), dictionary);
+        final EccairsTaxonomyToRdf exporter = new EccairsTaxonomyToRdf(conf.getBaseUri(), dictionary, taxonomyService);
         final Dataset dataset = exporter.transform();
         log.info("- taxonomy file parsed.");
 

--- a/eccairs-service/src/main/java/com/github/psiotwo/eccairs/taxonomy/EccairsTaxonomyService.java
+++ b/eccairs-service/src/main/java/com/github/psiotwo/eccairs/taxonomy/EccairsTaxonomyService.java
@@ -1,0 +1,191 @@
+package com.github.psiotwo.eccairs.taxonomy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.psiotwo.eccairs.core.model.EccairsValue;
+import com.github.psiotwo.eccairs.rdf.TaxonomyService;
+import com.jayway.jsonpath.*;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.*;
+import java.util.function.Supplier;
+
+@Slf4j
+@Component
+public class EccairsTaxonomyService implements TaxonomyService {
+
+    private static final int MAX_ATTEMPTS = 5;
+
+    @Value("${eccairs.taxonomyService.url}")
+    private String taxonomyServiceUrl;
+
+    private final RestTemplate client;
+
+    private Integer taxonomyVersionId;
+
+    private DocumentContext taxonomyTree;
+
+    /**
+     * Maps ECCAIRS attribute taxonomy identifiers (codes) to ECCAIRS internal identifiers.
+     * <p>
+     * This is a cache for better performance
+     */
+    private final Map<Integer, Integer> attributeIdMap = new HashMap<>();
+
+    public EccairsTaxonomyService(RestTemplateBuilder clientBuilder) {
+        this.client = clientBuilder.setConnectTimeout(Duration.ofMinutes(5)).build();
+        configureJsonPath();
+    }
+
+    @Override
+    public boolean hasHierarchicalValueList(int attributeId) {
+        if (taxonomyServiceUrl == null || taxonomyServiceUrl.isBlank()) {
+            log.warn("Taxonomy service URL not configured.");
+            return false;
+        }
+        initializeIfNecessary();
+        // Internal ECCAIRS id
+        final List<Integer> attIds = taxonomyTree.read("$..[?(@.tc==" + attributeId + " && @.type==\"A\")].id", new TypeRef<>() {});
+        if (attIds.isEmpty()) {
+            throw new IllegalArgumentException("Attribute with ECCAIRS ID " + attIds + " not found in the taxonomy tree!");
+        }
+        assert attIds.size() == 1;
+        final Integer attId = attIds.get(0);
+        attributeIdMap.put(attributeId, attId);
+        final TaxonomyServiceResponse attribute = getResponse(() -> client.getForEntity(taxonomyServiceUrl + "/attributes/public/byID/{attributeID}?taxonomyId={taxonomyID}", TaxonomyServiceResponse.class, attId, taxonomyVersionId));
+        assert attribute != null;
+        try {
+            return JsonPath.parse(attribute.getData().toString())
+                           .read("$.attributeValueList.levels", Integer.class) > 1;
+        } catch (PathNotFoundException e) {
+            log.trace("Attribute {} does not have a value list.", attributeId);
+            return false;
+        }
+    }
+
+    private TaxonomyServiceResponse getResponse(Supplier<ResponseEntity<TaxonomyServiceResponse>> request) {
+        try {
+            return attemptRequest(request, 0);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new WebServiceIntegrationException("Unable to perform request.", e);
+        }
+    }
+
+    private TaxonomyServiceResponse attemptRequest(Supplier<ResponseEntity<TaxonomyServiceResponse>> request,
+                                                   int attempt) throws InterruptedException {
+        try {
+            final ResponseEntity<TaxonomyServiceResponse> resp = request.get();
+            if (!resp.getStatusCode().is2xxSuccessful()) {
+                log.error("Failed to get response. Received {}.", resp);
+                throw new WebServiceIntegrationException("Unable to retrieve response. Got status " + resp.getStatusCode());
+            }
+            return resp.getBody();
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof ConnectException && attempt <= MAX_ATTEMPTS) {
+                log.warn("Failed to get response due to {}. Attempting again in 10s.", e.getMessage());
+                Thread.sleep(10000L);
+                return attemptRequest(request, attempt + 1);
+            }
+            throw new WebServiceIntegrationException("Unable to get response.", e);
+        }
+    }
+
+    private void initializeIfNecessary() {
+        if (taxonomyVersionId != null) {
+            return;
+        }
+        this.taxonomyVersionId = loadTaxonomyVersionId();
+        this.taxonomyTree = loadTaxonomyTree();
+    }
+
+    private Integer loadTaxonomyVersionId() {
+        final TaxonomyServiceResponse versionInfo = getResponse(() -> client.getForEntity(taxonomyServiceUrl + "/version/public/", TaxonomyServiceResponse.class));
+        assert versionInfo != null;
+        return JsonPath.parse(versionInfo.getData().toString()).read("$.id", Integer.class);
+    }
+
+    private DocumentContext loadTaxonomyTree() {
+        final TaxonomyServiceResponse tree = getResponse(() -> client.getForEntity(taxonomyServiceUrl + "/tree/public/", TaxonomyServiceResponse.class));
+        assert tree != null;
+        return JsonPath.parse(tree.getData().toString());
+    }
+
+    @Override
+    public List<EccairsValue> getValueList(int attributeId) {
+        if (taxonomyServiceUrl == null || taxonomyServiceUrl.isBlank()) {
+            log.warn("Taxonomy service URL not configured.");
+            return Collections.emptyList();
+        }
+        log.trace("Loading value list of attribute {}.", attributeId);
+        final List<EccairsValue> result = new ArrayList<>();
+        final Integer attId = attributeIdMap.get(attributeId);
+        final TaxonomyServiceResponse topLevel = getResponse(() -> client.getForEntity(taxonomyServiceUrl + "/attributes/public/showFirstLevelValues?attributesList={attributeID}", TaxonomyServiceResponse.class, attId));
+        topLevel.getData().get("map").get(Integer.toString(attId)).forEach(v -> {
+            final EccairsValue ev = initEccairsValue(v);
+            result.add(ev);
+            if (v.get("hasChild") != null && v.get("hasChild").asBoolean()) {
+                ev.setValues(getValueDescendants(attributeId, v.get("id").intValue(), 2));
+            }
+        });
+        return result;
+    }
+
+    private EccairsValue initEccairsValue(JsonNode valueNode) {
+        final EccairsValue ev = new EccairsValue();
+        ev.setId(valueNode.get("identifier").intValue());
+        ev.setDescription(valueNode.get("description").asText());
+        ev.setDetailedDescription(valueNode.get("detailed").asText());
+        ev.setLevel(valueNode.get("level").asText());
+        ev.setExplanation(valueNode.get("explanation").asText());
+        return ev;
+    }
+
+    private List<EccairsValue> getValueDescendants(int attributeId, int valId, int level) {
+        log.trace("Loading value list of attribute {}, level {}.", attributeId, level);
+        final List<EccairsValue> result = new ArrayList<>();
+        final TaxonomyServiceResponse children = getResponse(() -> client.getForEntity(taxonomyServiceUrl + "/listofvalue/public/childrenLov/{valueID}", TaxonomyServiceResponse.class, valId));
+        children.getData().get("list").forEach(v -> {
+            final EccairsValue ev = initEccairsValue(v);
+            result.add(ev);
+            if (v.get("hasChild") != null && v.get("hasChild").asBoolean()) {
+                ev.setValues(getValueDescendants(attributeId, v.get("id").intValue(), level + 1));
+            }
+        });
+        return result;
+    }
+
+    private static void configureJsonPath() {
+        Configuration.setDefaults(new Configuration.Defaults() {
+
+            private final JsonProvider jsonProvider = new JacksonJsonProvider();
+            private final MappingProvider mappingProvider = new JacksonMappingProvider();
+
+            @Override
+            public JsonProvider jsonProvider() {
+                return jsonProvider;
+            }
+
+            @Override
+            public MappingProvider mappingProvider() {
+                return mappingProvider;
+            }
+
+            @Override
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+        });
+    }
+}

--- a/eccairs-service/src/main/java/com/github/psiotwo/eccairs/taxonomy/TaxonomyServiceResponse.java
+++ b/eccairs-service/src/main/java/com/github/psiotwo/eccairs/taxonomy/TaxonomyServiceResponse.java
@@ -1,0 +1,16 @@
+package com.github.psiotwo.eccairs.taxonomy;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Data;
+
+@Data
+public class TaxonomyServiceResponse {
+
+    @JsonRawValue
+    private JsonNode data;
+
+    private String returnCode;
+
+    private String errorDetails;
+}

--- a/eccairs-service/src/main/java/com/github/psiotwo/eccairs/taxonomy/WebServiceIntegrationException.java
+++ b/eccairs-service/src/main/java/com/github/psiotwo/eccairs/taxonomy/WebServiceIntegrationException.java
@@ -1,0 +1,15 @@
+package com.github.psiotwo.eccairs.taxonomy;
+
+/**
+ * Indicates that a request to a remote service failed.
+ */
+public class WebServiceIntegrationException extends RuntimeException {
+
+    public WebServiceIntegrationException(String message) {
+        super(message);
+    }
+
+    public WebServiceIntegrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/eccairs-service/src/main/resources/application.yml
+++ b/eccairs-service/src/main/resources/application.yml
@@ -21,8 +21,8 @@ spring:
       enabled: DETECT
   servlet:
     multipart:
-      max-request-size: '200000KB'
-      max-file-size: '200000KB'
+      max-request-size: '400000KB'
+      max-file-size: '400000KB'
 
 server:
   port: 18080
@@ -34,11 +34,15 @@ logging:
     console: "%d{dd-MM-yyyy HH:mm:ss.SSS} [%X{username}] [thread] %-5level %logger{36} - %msg %n%throwable"
   level:
     root: INFO
+    com.github.psiotwo.eccairs: DEBUG
 
 eccairs:
   # Base URI for creating new IRIs
   baseUri: http://onto.fel.cvut.cz/ontologies/
   # SPARQL Query Protocol endpoint
-  sparqlQueryEndpoint: http://localhost:8080/rdf4j-server/repositories/eccairs-aviation-4.1.0.7
+  sparqlQueryEndpoint: http://localhost:18080/rdf4j-server/repositories/eccairs-aviation-5.1.1.2
   # SPARQL Graph Store Protocol endpoint template. Appending a named graph yields a GSP endpoint
-  sparqlGspEndpointTemplate: http://localhost:8080/rdf4j-server/repositories/eccairs-aviation-4.1.0.7/rdf-graphs/service?graph=
+  sparqlGspEndpointTemplate: http://localhost:18080/rdf4j-server/repositories/eccairs-aviation-5.1.1.2/rdf-graphs/service?graph=
+  # ECCAIRS taxonomy service URL
+  taxonomyService:
+    url:

--- a/eccairs-service/src/test/java/com/github/psiotwo/eccairs/EccairsControllerTest.java
+++ b/eccairs-service/src/test/java/com/github/psiotwo/eccairs/EccairsControllerTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.github.psiotwo.eccairs.core.model.EccairsDictionary;
 import java.nio.charset.StandardCharsets;
+
+import com.github.psiotwo.eccairs.rdf.TaxonomyService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +30,9 @@ public class EccairsControllerTest {
     @MockBean
     private EccairsService service;
 
+    @MockBean
+    private TaxonomyService taxonomyService;
+
     @Test
     void eccairsTaxonomyExistsForExistingTaxonomy_returns200() throws Exception {
         when(service.eccairsTaxonomyExists("aviation", "3.4.0.2"))
@@ -40,7 +45,7 @@ public class EccairsControllerTest {
     }
 
     @Test
-    void eccairsTaxonomyExistsForNonExisitngTaxonomy_returns404() throws Exception {
+    void eccairsTaxonomyExistsForNonExistingTaxonomy_returns404() throws Exception {
         when(service.eccairsTaxonomyExists("aviation", "3.4.0.2"))
             .thenReturn(true);
         mockMvc.perform(

--- a/eccairs-to-rdf/src/main/java/com/github/psiotwo/eccairs/rdf/TaxonomyService.java
+++ b/eccairs-to-rdf/src/main/java/com/github/psiotwo/eccairs/rdf/TaxonomyService.java
@@ -1,0 +1,27 @@
+package com.github.psiotwo.eccairs.rdf;
+
+import com.github.psiotwo.eccairs.core.model.EccairsValue;
+
+import java.util.List;
+
+/**
+ * Provides access to the ECCAIRS taxonomy service.
+ */
+public interface TaxonomyService {
+
+    /**
+     * Checks whether an attribute with the specified ECCAIRS ID has a hierarchical value list.
+     *
+     * @param attributeId Attribute ECCAIRS ID
+     * @return {@code} true when attribute value list has more than one level, {@code false} otherwise
+     */
+    boolean hasHierarchicalValueList(int attributeId);
+
+    /**
+     * Gets a presumably hierarchical value list of an attribute with the specified ECCAIRS ID.
+     *
+     * @param attributeId Attribute ECCAIRS ID
+     * @return List of top level attribute values
+     */
+    List<EccairsValue> getValueList(int attributeId);
+}

--- a/eccairs-to-rdf/src/test/java/com/github/psiotwo/eccairs/rdf/EccairsTaxonomyToRdfTest.java
+++ b/eccairs-to-rdf/src/test/java/com/github/psiotwo/eccairs/rdf/EccairsTaxonomyToRdfTest.java
@@ -30,7 +30,7 @@ public class EccairsTaxonomyToRdfTest {
     @Test
     public void exporterWritesTaxonomyNameCorrectly() {
         final EccairsDictionary dictionary = this.dictionary;
-        final EccairsTaxonomyToRdf r = new EccairsTaxonomyToRdf("https://test.org/", dictionary);
+        final EccairsTaxonomyToRdf r = new EccairsTaxonomyToRdf("https://test.org/", dictionary, null);
         final Dataset dataset = r.transform();
         final Model model = dataset.getUnionModel();
         final List<Resource> list = model.listSubjectsWithProperty(RDF.type, OWL.Ontology).toList();
@@ -43,7 +43,7 @@ public class EccairsTaxonomyToRdfTest {
     public void exporterWritesEntityAttributes() {
         final EccairsDictionary dictionary = this.dictionary;
         dictionary.setEntities(Collections.singletonList(entity));
-        final EccairsTaxonomyToRdf r = new EccairsTaxonomyToRdf("https://test.org/", dictionary);
+        final EccairsTaxonomyToRdf r = new EccairsTaxonomyToRdf("https://test.org/", dictionary, null);
         final Dataset dataset = r.transform();
         final Model model = dataset.getUnionModel();
         final List<Resource> entities =


### PR DESCRIPTION
Since ECCAIRS taxonomy XML no longer contains value list hierarchies, this PR uses the ECCAIRS taxonomy service to attempt to build the value list hierarchy.

It has to retrieve internal ECCAIRS id of the attribute, then get the top level of the value list and then recursively for each item load its descendants.

Another modification is that the transformation to RDF remembers already processed attributes and skips their repeated processing (the XML now contains certain attributes with value lists multiple times). This speeds up the transformation, but given the dependency on the ECCAIRS taxonomy service, it still takes around 10 minutes to process.